### PR TITLE
Do not rollback automatically when error is thrown.

### DIFF
--- a/javasource/processqueue/queuehandler/ObjectQueueExecutor.java
+++ b/javasource/processqueue/queuehandler/ObjectQueueExecutor.java
@@ -167,9 +167,10 @@ public class ObjectQueueExecutor implements Runnable {
 				try 
 				{
 					// Start the microflow of the action.
-					this.context.startTransaction();
 					try {
-						Object booleanResult = Core.execute(this.context, this.microflowName, this.action);
+						HashMap<String, Object> paramMap = new HashMap<String, Object>();
+						paramMap.put("QueuedAction", this.action);
+						Object booleanResult = Core.execute(this.context, this.microflowName, true, paramMap);
 
 						this._state = State.executionComplete;
 						
@@ -182,7 +183,6 @@ public class ObjectQueueExecutor implements Runnable {
 
 					} catch (Exception e) {
 						this._state = State.executionFailed;
-						this.context.rollbackTransAction();
 						_logNode.error("Error while executing: " + this.microflowName + " from the queue", e);
 						setErrormessageAndCommit(this.context, this.action, "Error occured while executing the process, error:" + e.getMessage(), e, LogExecutionStatus.FailedExecuted, ( microflowResult != null && microflowResult ? ActionStatus.Finished : ActionStatus.Cancelled) );
 					} finally {


### PR DESCRIPTION
An error without rollback will work with a microflow running from the queue.
This gives the Mendix Developer the freedom to use custom error handling in the microflows running from the queue and throw an exception without rollback.