### PR TITLE
Update ObjectQueueExecutor.java

### DIFF
--- a/javasource/processqueue/queuehandler/ObjectQueueExecutor.java
+++ b/javasource/processqueue/queuehandler/ObjectQueueExecutor.java
@@ -223,15 +223,15 @@ public class ObjectQueueExecutor implements Runnable {
 						this._state = State.finishedFollowup;
 					}
 				} catch (Exception e) {
-					_logNode.info("Error during commit from queue", e);
-					setErrormessageAndCommit(this.context, this.action, "An unknown error occured. Please contact your system administrator.", e, LogExecutionStatus.FailedExecuted, ActionStatus.Cancelled);
+					_logNode.error("Error during commit from queue", e);
+					setErrormessageAndCommit(Core.createSystemContext(), this.action, "An unknown error occured. Please contact your system administrator.", e, LogExecutionStatus.FailedExecuted, ActionStatus.Cancelled);
 				}
 			}
 		} catch (Exception e) {
 			this._state = State.failed;
 			// Microflow is being rollbacked
 			_logNode.error("Error during committing errormessage from queue", e);
-			setErrormessageAndCommit(this.context, this.action, "An unknown error occured. Please contact your system administrator.", e, LogExecutionStatus.FailedExecuted, ActionStatus.Cancelled);
+			setErrormessageAndCommit(Core.createSystemContext(), this.action, "An unknown error occured. Please contact your system administrator.", e, LogExecutionStatus.FailedExecuted, ActionStatus.Cancelled);
 		}
 		finally {
 			this._state = State.threadFinished;


### PR DESCRIPTION
This chang is to fix an issue with a catched exception that is caused by a failing database transaction (for example not explicitly committed objects that are in the state 'Autocommitted'). Currently the process queue is only creating an info log but it is obviously an error. Changed it to error. Using the existing context for the setErrormessageAndCommit method is causing the changes made by his action to be rolled back with the entire transaction. I created a new system context to run this action. If you don't do that, the QueuedAction will remain in running forever, even if it is already terminated.